### PR TITLE
fixed to be compatible for Wordpress 3.5.2

### DIFF
--- a/export.plugin.php
+++ b/export.plugin.php
@@ -246,7 +246,7 @@
 				
 				// figure out the type of the post
 				if ( $post->content_type == Post::type( 'entry' ) ) {
-					$type = 'post';		// blog posts are normal
+					$type = 'normal';		// blog posts are normal
 				}
 				else {
 					$type = 'article';		// articles are pages, i think
@@ -352,7 +352,7 @@
 				$item->{'wp:status'} = $post->status == Post::status('published') ? 'publish' : 'draft';
 				$item->{'wp:post_parent'} = 0;
 				$item->{'wp:menu_order'} = 0;
-				$item->{'wp:post_type'} = $post->typename;
+				$item->{'wp:post_type'} = ($post->typename == "entry" ? "post" : $post->typename);
 				$item->{'wp:post_password'} = '';
 				
 				$tags = $post->tags;


### PR DESCRIPTION
The current code doesn't import into Wordpress 3.5.2, I investigated and made the changes necessary to have them work together. My PHP isn't exactly up to scratch, but the changes that are supposed to be made are:

1) wp:post_type should be "post" and not "entry"
2) wp:status should be "publish" and not "published"
3) the </channel> tag closes prematurely (and twice!)
